### PR TITLE
Fix podcast list

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
+import { Pane } from 'evergreen-ui';
 import PodcastContainer from './PodcastContainer';
 
-const footerStyle = {
-  position: 'absolute',
-  bottom: '-4px',
-  width: '100%',
-};
-
 const Footer = episodes => (
-  <div style={footerStyle}>
+  <Pane background="tint2" position="absolute" bottom="-4px" width="100%">
     <PodcastContainer episodes={episodes.episodes} />
-  </div>
+  </Pane>
 );
 
 export default Footer;

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PodcastContainer from './PodcastContainer';
 
 const footerStyle = {
   position: 'absolute',
@@ -6,18 +7,9 @@ const footerStyle = {
   width: '100%',
 };
 
-const PIPPA_EMBED_URL = 'https://player.pippa.io/bitfaced?theme=default&cover=1&latest=1';
-
-const Footer = () => (
+const Footer = episodes => (
   <div style={footerStyle}>
-    <iframe
-      title="Bitfaced Podcast Media Player"
-      src={PIPPA_EMBED_URL}
-      frameBorder="0"
-      width="100%"
-      height="220px"
-      allow="autoplay"
-    />
+    <PodcastContainer episodes={episodes.episodes} />
   </div>
 );
 

--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -13,7 +13,12 @@ const layoutStyle = {
   width: '100%',
 };
 
-const Layout = ({ onContentChange, children, latestPodcast }) => (
+const Layout = ({
+  onContentChange,
+  children,
+  latestPodcast,
+  episodes,
+}) => (
   <div style={layoutStyle}>
     <Toast
       style={{ padding: 8, zIndex: 19 }}
@@ -24,7 +29,7 @@ const Layout = ({ onContentChange, children, latestPodcast }) => (
       latestPodcast={latestPodcast}
     />
     {children}
-    <Footer />
+    <Footer episodes={episodes} />
   </div>
 );
 
@@ -35,6 +40,10 @@ Layout.propTypes = {
     title: PropTypes.string,
     content: PropTypes.string,
   }),
+  episodes: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    link: PropTypes.string,
+  })),
 };
 
 Layout.defaultProps = {
@@ -43,6 +52,7 @@ Layout.defaultProps = {
     title: '',
     content: '',
   },
+  episodes: [],
 };
 
 export default Layout;

--- a/components/PodcastContainer.jsx
+++ b/components/PodcastContainer.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import PodcastPlayer from './PodcastPlayer';
+import PodcastList from './PodcastList';
+
+class PodcastContainer extends React.Component {
+  static propTypes = {
+    episodes: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      link: PropTypes.string,
+    })).isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentEpisodeLink: this.getLatestEpisode().link,
+    };
+  }
+
+  getLatestEpisode() {
+    const { episodes } = this.props;
+    return episodes[0];
+  }
+
+  updatePlayer = (newEpisode) => {
+    this.setState({
+      currentEpisodeLink: newEpisode.link,
+    });
+  }
+
+  render() {
+    const { currentEpisodeLink } = this.state;
+    const { episodes } = this.props;
+    return (
+      <div>
+        <PodcastPlayer embedUrl={currentEpisodeLink} />
+        <PodcastList episodes={episodes} onEpisodeSelect={this.updatePlayer} />
+      </div>
+    );
+  }
+}
+
+export default PodcastContainer;

--- a/components/PodcastList.jsx
+++ b/components/PodcastList.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Table } from 'evergreen-ui';
+
+const HEIGHT_EPISODE_LIST = 240;
+
+class PodcastList extends React.Component {
+  static propTypes = {
+    episodes: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      link: PropTypes.string,
+    })).isRequired,
+    onEpisodeSelect: PropTypes.func.isRequired,
+  };
+
+  getLatestEpisode() {
+    const { episodes } = this.props;
+    return episodes[episodes.length - 1];
+  }
+
+  renderEpisodeList() {
+    const { episodes, onEpisodeSelect } = this.props;
+    const rows = [];
+    episodes.forEach((episode) => {
+      rows.push(
+        <Table.Row
+          key={episode.link}
+          isSelectable
+          onSelect={() => {
+            onEpisodeSelect(episode);
+          }}
+        >
+          <Table.TextCell>
+            {episode.title}
+          </Table.TextCell>
+        </Table.Row>,
+      );
+    });
+
+    return rows;
+  }
+
+  render() {
+    return (
+      <Table background="tint2">
+        <Table.Body height={HEIGHT_EPISODE_LIST}>
+          { this.renderEpisodeList() }
+        </Table.Body>
+      </Table>
+    );
+  }
+}
+
+export default PodcastList;

--- a/components/PodcastPlayer.jsx
+++ b/components/PodcastPlayer.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+// rss feed has share links instead of embed links.
+function swapUrlFromShareToEmbed(url) {
+  return url.replace('/s/', '/e/');
+}
+
+const PodcastPlayer = embedUrl => (
+  <div>
+    <iframe
+      title="Bitfaced Podcast Media Player"
+      src={swapUrlFromShareToEmbed(embedUrl.embedUrl)}
+      frameBorder="0"
+      width="100%"
+      height="220px"
+      allow="autoplay"
+    />
+  </div>
+);
+
+export default PodcastPlayer;

--- a/components/content/About.jsx
+++ b/components/content/About.jsx
@@ -3,8 +3,8 @@ import {
   Dialog,
 } from 'evergreen-ui';
 import { PropTypes } from 'prop-types';
-import { DEFAULT_CONTENT_NODE } from '../../constants';
 import AboutPane from './AboutPane';
+import settings from '../../utilities/siteSettings';
 
 const aboutContainerStyles = {
   width: '80%',
@@ -60,7 +60,7 @@ class AboutContent extends React.Component {
   onClose = () => {
     const { onContentChange } = this.props;
 
-    onContentChange(DEFAULT_CONTENT_NODE);
+    onContentChange(settings.DEFAULT_CONTENT);
   }
 
   render() {

--- a/components/content/Contact.jsx
+++ b/components/content/Contact.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Dialog, Heading } from 'evergreen-ui';
 import { PropTypes } from 'prop-types';
-import { DEFAULT_CONTENT_NODE } from '../../constants';
+import settings from '../../utilities/siteSettings';
 
 const aboutContainerStyles = {
   width: '80%',
@@ -23,7 +23,7 @@ class ContactContent extends React.Component {
   onClose = () => {
     const { onContentChange } = this.props;
 
-    onContentChange(DEFAULT_CONTENT_NODE);
+    onContentChange(settings.DEFAULT_CONTENT);
   }
 
   render() {

--- a/components/content/ContentContainer.jsx
+++ b/components/content/ContentContainer.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactGA from 'react-ga';
 import { PropTypes } from 'prop-types';
 import {
-  DEFAULT_CONTENT_NODE,
   CONTENT_NODES,
 } from '../../constants';
+import settings from '../../utilities/siteSettings';
 
 class ContentContainer extends React.Component {
   static propTypes = {
@@ -13,7 +13,7 @@ class ContentContainer extends React.Component {
   };
 
   static defaultProps = {
-    activeContent: DEFAULT_CONTENT_NODE,
+    activeContent: settings.DEFAULT_CONTENT,
   };
 
   constructor(props) {

--- a/components/content/Develop.jsx
+++ b/components/content/Develop.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Dialog, Heading, Link } from 'evergreen-ui';
 import { PropTypes } from 'prop-types';
-import { DEFAULT_CONTENT_NODE } from '../../constants';
+import settings from '../../utilities/siteSettings';
 
 const aboutContainerStyles = {
   width: '80%',
@@ -23,7 +23,7 @@ class DevelopContent extends React.Component {
   onClose = () => {
     const { onContentChange } = this.props;
 
-    onContentChange(DEFAULT_CONTENT_NODE);
+    onContentChange(settings.DEFAULT_CONTENT);
   }
 
   render() {

--- a/components/content/Home.jsx
+++ b/components/content/Home.jsx
@@ -5,32 +5,35 @@ import React from 'react';
 import MediaQuery from 'react-responsive';
 import { PropTypes } from 'prop-types';
 
+const PORTRAIT_BOTTOM = '410px';
+const PORTRAIT_LANDSCAPE = '415px';
+
 const logoStylesPortrait = {
   width: '70%',
   marginLeft: '15%',
   position: 'absolute',
-  bottom: '210px',
+  bottom: PORTRAIT_BOTTOM,
 };
 
 const logoStylesSmallPortrait = {
   width: '50%',
   marginLeft: '25%',
   position: 'absolute',
-  bottom: '210px',
+  bottom: PORTRAIT_BOTTOM,
 };
 
 const logoStylesLandscape = {
   width: '20%',
   marginLeft: '40%',
   position: 'absolute',
-  bottom: '215px',
+  bottom: PORTRAIT_LANDSCAPE,
 };
 
 const logoStylesBigLandscape = {
   width: '30%',
   marginLeft: '35%',
   position: 'absolute',
-  bottom: '215px',
+  bottom: PORTRAIT_LANDSCAPE,
 };
 
 class HomeContent extends React.Component {

--- a/components/content/Home.jsx
+++ b/components/content/Home.jsx
@@ -5,8 +5,8 @@ import React from 'react';
 import MediaQuery from 'react-responsive';
 import { PropTypes } from 'prop-types';
 
-const PORTRAIT_BOTTOM = '410px';
-const PORTRAIT_LANDSCAPE = '415px';
+const PORTRAIT_BOTTOM = '460px';
+const PORTRAIT_LANDSCAPE = '455px';
 
 const logoStylesPortrait = {
   width: '70%',

--- a/components/content/PacMan.jsx
+++ b/components/content/PacMan.jsx
@@ -4,8 +4,7 @@ import {
   CornerDialog,
 } from 'evergreen-ui';
 import fetch from 'isomorphic-unfetch';
-
-import { DEFAULT_CONTENT_NODE } from '../../constants';
+import settings from '../../utilities/siteSettings';
 
 
 class PacManContent extends React.Component {
@@ -46,7 +45,7 @@ class PacManContent extends React.Component {
   onClose = () => {
     const { onContentChange } = this.props;
 
-    onContentChange(DEFAULT_CONTENT_NODE);
+    onContentChange(settings.DEFAULT_CONTENT);
   }
 
   render() {

--- a/components/content/Social.jsx
+++ b/components/content/Social.jsx
@@ -8,7 +8,7 @@ import {
   Heading,
 } from 'evergreen-ui';
 import { PropTypes } from 'prop-types';
-import { DEFAULT_CONTENT_NODE } from '../../constants';
+import settings from '../../utilities/siteSettings';
 
 const aboutContainerStyles = {
   width: '80%',
@@ -30,7 +30,7 @@ class SocialContent extends React.Component {
   onClose = () => {
     const { onContentChange } = this.props;
 
-    onContentChange(DEFAULT_CONTENT_NODE);
+    onContentChange(settings.DEFAULT_CONTENT);
   }
 
   render() {

--- a/components/content/Team.jsx
+++ b/components/content/Team.jsx
@@ -3,8 +3,8 @@ import {
   Dialog,
 } from 'evergreen-ui';
 import { PropTypes } from 'prop-types';
-import { DEFAULT_CONTENT_NODE } from '../../constants';
 import AboutPane from './AboutPane';
+import settings from '../../utilities/siteSettings';
 
 const aboutContainerStyles = {
   width: '80%',
@@ -77,7 +77,7 @@ class TeamContent extends React.Component {
   onClose = () => {
     const { onContentChange } = this.props;
 
-    onContentChange(DEFAULT_CONTENT_NODE);
+    onContentChange(settings.DEFAULT_CONTENT);
   }
 
   render() {

--- a/constants.jsx
+++ b/constants.jsx
@@ -73,6 +73,4 @@ export const CONTENT_NODES = {
   },
 };
 
-export const DEFAULT_CONTENT_NODE = 'home';
-
 export const noop = () => {};

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -5,7 +5,7 @@ import { PropTypes } from 'prop-types';
 
 import Layout from '../components/Layout';
 import ContentContainer from '../components/content/ContentContainer';
-import { DEFAULT_CONTENT_NODE } from '../constants';
+import settings from '../utilities/siteSettings';
 
 const url = process.env.NODE_ENV !== 'production'
   ? 'http://localhost:3000/api/podcast/latest'
@@ -39,7 +39,7 @@ class Index extends React.Component {
     super(props);
 
     this.state = {
-      activeContent: DEFAULT_CONTENT_NODE,
+      activeContent: settings.DEFAULT_CONTENT,
     };
 
     ReactGA.initialize('UA-83285751-1');

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -7,17 +7,26 @@ import Layout from '../components/Layout';
 import ContentContainer from '../components/content/ContentContainer';
 import settings from '../utilities/siteSettings';
 
-const url = process.env.NODE_ENV !== 'production'
+const episodeLatestUrl = process.env.NODE_ENV !== 'production'
   ? 'http://localhost:3000/api/podcast/latest'
   : 'http://bitfaced.com/api/podcast/latest';
 
+const episodeListUrl = process.env.NODE_ENV !== 'production'
+  ? 'http://localhost:3000/api/podcast/list'
+  : 'http://bitfaced.com/api/podcast/list';
+
+
 class Index extends React.Component {
   static async getInitialProps() {
-    const res = await fetch(url);
+    const res = await fetch(episodeLatestUrl);
     const data = await res.json();
+
+    const result = await fetch(episodeListUrl);
+    const episodes = await result.json();
 
     return {
       latestPodcast: data,
+      episodes,
     };
   }
 
@@ -26,6 +35,10 @@ class Index extends React.Component {
       title: PropTypes.string,
       content: PropTypes.string,
     }),
+    episodes: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      link: PropTypes.string,
+    })),
   };
 
   static defaultProps = {
@@ -33,6 +46,7 @@ class Index extends React.Component {
       title: '',
       content: '',
     },
+    episodes: [],
   };
 
   constructor(props) {
@@ -58,12 +72,14 @@ class Index extends React.Component {
 
     const {
       latestPodcast,
+      episodes,
     } = this.props;
 
     return (
       <Layout
         onContentChange={this.onContentChange}
         latestPodcast={latestPodcast}
+        episodes={episodes}
       >
         <ContentContainer
           activeContent={activeContent}

--- a/server.js
+++ b/server.js
@@ -21,8 +21,25 @@ app.prepare()
     // GET method route
     server.get('/api/podcast/latest', (req, res) => {
       getRssData().then((data) => {
+        const { title, content } = data.items[0];
+        const latestFeedItem = { title, content };
         res.setHeader('Content-Type', 'application/json');
-        res.send(JSON.stringify(data));
+        res.send(JSON.stringify(latestFeedItem));
+      });
+    });
+
+    server.get('/api/podcast/list', (req, res) => {
+      getRssData().then((data) => {
+        const podcasts = [];
+        data.items.forEach((item) => {
+          podcasts.push({
+            title: item.title,
+            link: item.link,
+
+          });
+        });
+        res.setHeader('Content-Type', 'application/json');
+        res.send(JSON.stringify(podcasts));
       });
     });
 

--- a/server/api/bfRssToJson.js
+++ b/server/api/bfRssToJson.js
@@ -3,7 +3,7 @@ const Parser = require('rss-parser');
 const parser = new Parser();
 const date = new Date();
 
-const rssToJson = () => parser.parseURL(`https://feed.pippa.io/public/shows/bitfaced?t=${date}`).then((feed) => {
+const rssToJson = () => parser.parseURL(`https://feeds.transistor.fm/bitfaced?t=${date}`).then((feed) => {
   const {
     title,
     content,

--- a/server/api/bfRssToJson.js
+++ b/server/api/bfRssToJson.js
@@ -4,15 +4,7 @@ const parser = new Parser();
 const date = new Date();
 
 const rssToJson = () => parser.parseURL(`https://feeds.transistor.fm/bitfaced?t=${date}`).then((feed) => {
-  const {
-    title,
-    content,
-  } = feed.items[0];
-
-  return {
-    title,
-    content,
-  };
+  return feed;
 });
 
 module.exports = rssToJson;

--- a/utilities/siteSettings.js
+++ b/utilities/siteSettings.js
@@ -1,0 +1,5 @@
+const settings = {
+  DEFAULT_CONTENT: 'home',
+};
+
+export default settings;


### PR DESCRIPTION
I updated the RSS code on the server side to just return the entire feed. The latest api endpoint now handles pulling off the title and content from the first item. The new list endpoint returns the title and the link provided by rss feed.

The rss feed delivers links that point at landing pages. We want the embedded link instead; luckily just changing an s(share) to an e(embed) allows us to achieve this without crazy magic!

I tried moving the logo around to sit on top of the new page. iTried.